### PR TITLE
Fetch Yearly Temperature Data for Line Chart from Open-Meteo API

### DIFF
--- a/backend/routes/weatherRoutes.js
+++ b/backend/routes/weatherRoutes.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const router = express.Router();
+const { getMonthlyAverageTemperature } = require('../services/weatherService');
+
+// Route to fetch monthly average temperatures
+router.get('/monthly-average', async (req, res) => {
+  const { latitude, longitude, start_date, end_date } = req.query;
+
+  // Validate required query parameters
+  if (!latitude || !longitude || !start_date || !end_date) {
+    return res.status(400).json({ error: 'Missing required query parameters' });
+  }
+
+  try {
+    // Fetch and process weather data
+    const monthlyData = await getMonthlyAverageTemperature(latitude, longitude, start_date, end_date);
+    res.json(monthlyData);
+  } catch (error) {
+    console.error('Error fetching monthly average temperature:', error);
+    res.status(500).json({ error: 'Failed to fetch data' });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,10 @@
 const express = require('express');
 const app = express();
-const homepageRoutes = require('./routes/homepage');
 const cors = require('cors');
+
+const homepageRoutes = require('./routes/homepage');
+// Import the new weather routes
+const weatherRoutes = require('./routes/weatherRoutes');
 
 app.use(cors({
     origin: 'http://localhost:5173',
@@ -14,6 +17,9 @@ app.use(express.json());
 
 // Routes
 app.use('/api/homepage', homepageRoutes);
+
+// New route for weather-related requests
+app.use('/api/weather', weatherRoutes);
 
 // Error handling middleware
 app.use((err, req, res, next) => {

--- a/backend/services/weatherService.js
+++ b/backend/services/weatherService.js
@@ -1,0 +1,52 @@
+const axios = require('axios');
+
+// Open-Meteo API base URL
+const BASE_URL = 'https://archive-api.open-meteo.com/v1/archive';
+
+// Fetch daily temperature data and calculate monthly averages
+const getMonthlyAverageTemperature = async (latitude, longitude, startDate, endDate) => {
+  try {
+    // Request daily temperature data from Open-Meteo API
+    const response = await axios.get(BASE_URL, {
+      params: {
+        latitude,
+        longitude,
+        start_date: startDate,
+        end_date: endDate,
+        daily: 'temperature_2m_mean',
+        timezone: 'auto',
+      },
+    });
+
+    const { time, temperature_2m_mean } = response.data.daily;
+
+    // Aggregate daily data into monthly averages
+    const monthlyData = aggregateMonthlyData(time, temperature_2m_mean);
+
+    return monthlyData;
+  } catch (error) {
+    console.error('Error fetching daily data from Open-Meteo:', error);
+    throw error;
+  }
+};
+
+// Helper function to group daily data by month and calculate averages
+const aggregateMonthlyData = (timeArray, temperatureArray) => {
+  const monthlyData = {};
+
+  timeArray.forEach((date, index) => {
+    const month = date.slice(0, 7); // Extract year and month (e.g., "2023-01")
+    if (!monthlyData[month]) {
+      monthlyData[month] = [];
+    }
+    monthlyData[month].push(temperatureArray[index]);
+  });
+
+  // Calculate the average temperature for each month
+  return Object.entries(monthlyData).map(([month, temps]) => ({
+    month,
+    avgTemperature: (temps.reduce((sum, temp) => sum + temp, 0) / temps.length).toFixed(1), // Keep one decimal place
+  }));
+};
+
+module.exports = { getMonthlyAverageTemperature };

--- a/frontend/src/components/LineChart.jsx
+++ b/frontend/src/components/LineChart.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Line } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
@@ -8,7 +8,7 @@ import {
   LineElement,
   Title,
   Tooltip,
-  Legend
+  Legend,
 } from 'chart.js';
 
 ChartJS.register(
@@ -21,64 +21,80 @@ ChartJS.register(
   Legend
 );
 
-const LineChart = ({ data = [] }) => {
-  // Check if data is valid
-  if (!Array.isArray(data) || data.length === 0) {
-    return <div>Loading temperature data...</div>;
+const LineChart = ({ data }) => {
+  const [unit, setUnit] = useState('C'); // Manage unit state locally in the chart
+
+  if (!data || data.length === 0) {
+    return <div>No data available</div>;
   }
 
+  // Convert temperatures based on the selected unit
+  const convertedData = data.map(item => ({
+    ...item,
+    avgTemperature:
+      unit === 'C'
+        ? item.avgTemperature // Keep as Celsius
+        : (item.avgTemperature * 9) / 5 + 32, // Convert to Fahrenheit
+  }));
+
   const chartData = {
-    // X-axis: months
-    labels: data.map(item => item.month),
+    labels: convertedData.map(item => item.month), // X-axis: Months
     datasets: [
       {
-        label: 'Monthly Average Temperature (°C)',
-        // Y-axis: temperature values
-        data: data.map(item => item.avgTemperature),
-        borderColor: 'rgb(75, 192, 192)',
-        backgroundColor: 'rgba(75, 192, 192, 0.2)',
+        label: `Monthly Average Temperature (°${unit})`,
+        data: convertedData.map(item => item.avgTemperature), // Y-axis: Temperatures
+        borderColor: 'rgb(75,192,192)',
+        backgroundColor: 'rgba(75,192,192,0.2)',
         tension: 0.3,
-        fill: true
-      }
-    ]
+        fill: true,
+      },
+    ],
   };
 
   const options = {
     responsive: true,
-    aspectRatio: 4,
-    maintainAspectRatio: true,
     plugins: {
-      legend: {
-        position: 'top',
-      },
-      title: {
-        display: true,
-        text: 'Monthly Temperature Trends'
-      },
+      legend: { position: 'top' },
+      title: { display: true, text: 'Monthly Temperature Trends' },
       tooltip: {
         callbacks: {
-          label: (context) => `Temperature: ${context.parsed.y}°C`
-        }
-      }
+          label: context => `Temperature: ${context.parsed.y}°${unit}`, // Show unit in tooltip
+        },
+      },
     },
     scales: {
       y: {
         beginAtZero: false,
-        title: {
-          display: true,
-          text: 'Temperature (°C)'
-        }
+        title: { display: true, text: `Temperature (°${unit})` }, // Show unit in Y-axis label
       },
-      x: {
-        title: {
-          display: true,
-          text: 'Month'
-        }
-      }
-    }
+      x: { title: { display: true, text: 'Month' } },
+    },
   };
 
-  return <Line data={chartData} options={options} />;
+  return (
+    <div style={{ position: 'relative', width: '100%' }}>
+      {/* Toggle Buttons */}
+      <div style={{ textAlign: 'right', marginBottom: '10px' }}>
+        <button 
+          onClick={() => setUnit('C')} 
+          disabled={unit === 'C'}
+          style={{ marginRight: '10px', padding: '5px', cursor: unit === 'C' ? 'not-allowed' : 'pointer' }}
+        >
+          Celsius (°C)
+        </button>
+        <button 
+          onClick={() => setUnit('F')} 
+          disabled={unit === 'F'}
+          style={{ padding: '5px', cursor: unit === 'F' ? 'not-allowed' : 'pointer' }}
+        >
+          Fahrenheit (°F)
+        </button>
+      </div>
+
+      {/* Line Chart */}
+      <Line data={chartData} options={options} />
+    </div>
+  );
 };
 
 export default LineChart;


### PR DESCRIPTION
This pull request updated the LineChart on the homepage to fetch temperature data dynamically from outside API instead of using dynamoDB data. 

Frontend:
Updated `DashboardPage.jsx` to fetch temperature data from the backend API.
Modified `LineChart.jsx` to include unit toggle functionality and handle dynamic temperature conversion.

Backend:
Added `/api/weather/monthly-average` endpoint to fetch monthly average temperatures from Open-Meteo API. 

**Open-Meteo API Restrictions(Free Tier Usage):**
Non-Commercial Use Only: The free API is intended strictly for non-commercial applications.
No API Key Required: Users can access the free tier without needing an API key.
Daily Request Limit:
The API allows up to 10,000 API calls per day for free users.
Exceeding this limit may result in IP blocking or service denial.
<img width="756" alt="Screenshot 2024-12-25 at 7 39 17 PM" src="https://github.com/user-attachments/assets/36f4a6a5-0f04-4d3a-a3e0-08cebf452322" />
