### PR TITLE
feat: add  Remember Me support with extended JWT expiry

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -7,8 +7,9 @@ const LoginPage = () => {
     const [username, setUsername] = React.useState("");
     const [password, setPassword] = React.useState("");
     const [error, setError] = React.useState("");
+    const [rememberMe, setRememberMe] = React.useState(false);
 
-    console.log("LoginPage is rendering");//debug
+    //console.log("LoginPage is rendering");//debug
 
     // visitor mode
     const handleVisitorMode = () => {
@@ -25,7 +26,7 @@ const LoginPage = () => {
           headers: {
             "Content-Type": "application/json"
           },
-          body: JSON.stringify({ username, password })
+          body: JSON.stringify({ username, password, rememberMe })
         });
   
         const data = await res.json();
@@ -73,6 +74,16 @@ const LoginPage = () => {
                 />
               </div>
             </div>
+
+            <div className="checkbox-container">
+              <input
+                type="checkbox"
+                id="rememberMe"
+                checked={rememberMe}
+                onChange={(e) => setRememberMe(e.target.checked)}
+              />
+              <label htmlFor="rememberMe">Remember Me</label>
+          </div>
 
             {error && <p className="error-msg">{error}</p>}
 

--- a/frontend/src/styles/LoginPage.css
+++ b/frontend/src/styles/LoginPage.css
@@ -157,3 +157,15 @@
   .register-nav-button:hover {
     background: #005fa3;
   }
+
+  .checkbox-container {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: -10px;
+    margin-bottom: 10px;
+    font-size: 14px;
+    color: #333;
+    padding-left: 8px;
+  }
+  


### PR DESCRIPTION
- added "Remember Me" checkbox to login form (frontend);
- backend accepts rememberMe from login payload;
- JWT expiresIn is set to 7days if "Remember Me" is checked, otherwise defaults to 1h;
- close #53 